### PR TITLE
Ensure declaration of function matches its definition

### DIFF
--- a/modules/mod-script-pipe/PipeServer.cpp
+++ b/modules/mod-script-pipe/PipeServer.cpp
@@ -8,7 +8,7 @@
 const int nBuff = 1024;
 
 extern "C" int DoSrv( char * pIn );
-extern "C" int DoSrvMore( char * pOut, int nMax );
+extern "C" int DoSrvMore( char * pOut, size_t nMax );
 
 void PipeServer()
 {
@@ -119,7 +119,7 @@ const char fifotmpl[] = "/tmp/audacity_script_pipe.%s.%d";
 const int nBuff = 1024;
 
 extern "C" int DoSrv( char * pIn );
-extern "C" int DoSrvMore( char * pOut, int nMax );
+extern "C" int DoSrvMore( char * pOut, size_t nMax );
 
 void PipeServer()
 {


### PR DESCRIPTION
It was defined as taking a size_t paramater when it was written,
so the declarations used to call it should also use a size_t parameter
to ensure the call is correct.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
