### PR TITLE
Issue2372: Nyquist can hang ...

### DIFF
--- a/lib-src/libnyquist/nyquist/xlisp/xlread.c
+++ b/lib-src/libnyquist/nyquist/xlisp/xlread.c
@@ -185,13 +185,14 @@ int xlload(const char *fname, int vflag, int pflag)
 
     /* read, evaluate and possibly print each expression in the file */
     xlbegin(&cntxt,CF_ERROR,s_true);
-    if (_setjmp(cntxt.c_jmpbuf))
+    if (_setjmp(cntxt.c_jmpbuf)) {
         sts = FALSE;
         #ifdef DEBUG_INPUT
             if (read_by_xlisp) {
 		fprintf(read_by_xlisp, ";;;;xlload: catch longjump, back to %s\n", fullname);
             }
         #endif
+    }
     else {
         #ifdef DEBUG_INPUT
             if (read_by_xlisp) {
@@ -277,14 +278,14 @@ int xlread(LVAL fptr, LVAL *pval, int rflag)
     int sts;
 
     /* read an expression */
-    while ((sts = readone(fptr,pval)) == FALSE)
+    while ((sts = readone(fptr,pval)) == FALSE) {
 #ifdef DEBUG_INPUT
     if (debug_input_fp) {
         int c = getc(debug_input_fp);
         ungetc(c, debug_input_fp);
     }
 #endif
-        ;
+    }
 
     /* return status */
     return (sts == EOF ? FALSE : TRUE);

--- a/lib-src/libnyquist/nyx.c
+++ b/lib-src/libnyquist/nyx.c
@@ -905,6 +905,8 @@ nyx_rval nyx_eval_expression(const char *expr_string)
 
  finish:
 
+   xlend(&nyx_cntxt);
+
    xlflush();
 
    xlpop(); // unprotect expr
@@ -1112,6 +1114,8 @@ int nyx_get_audio(nyx_audio_callback callback, void *userdata)
    // Never reached
 
  finish:
+
+   xlend(&nyx_cntxt);
 
    if (buffer) {
       free(buffer);


### PR DESCRIPTION
... Problem was xlbegin() calls not balanced by xlend().  This can cause
the global variable xlcontext in the XLisp interpreter to be a dangling pointer
to an expired stack variable.  When re-entering the interpreter, the context
was again constructed at the coincidental same address, but it should have been
NULL.  This caused xlreturn() to enter a tight infinite loop, when evaluating
a simple `(return 0)` in Nyquist prompt.

I reviewed and fixed all unbalanced xlbegin() calls, other than in xlisp_main().

Those in nyx.c affect Audacity, one of them when evaluating a sound, another
when evaluating other values; but should not be reached in standalone Nyquist.

Also: fix dangling else in xlread.c in case DEBUG_INPUT is enabled.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
